### PR TITLE
fix 'center_shift=nan' bug and add a dependency 'numba' for installing from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ git clone https://github.com/subhadarship/kmeans_pytorch
 cd kmeans_pytorch
 pip install --editable .
 ```
+Installing from source requires 'numba' dependency.
 
 # CPU vs GPU
 see [`cpu_vs_gpu.ipynb`](https://github.com/subhadarship/kmeans_pytorch/blob/master/cpu_vs_gpu.ipynb) for a comparison between CPU and GPU

--- a/kmeans_pytorch/__init__.py
+++ b/kmeans_pytorch/__init__.py
@@ -101,7 +101,8 @@ def kmeans(
             if selected.shape[0] == 0:
                 selected = X[torch.randint(len(X), (1,))]
 
-            initial_state[index] = selected.mean(dim=0)
+            if torch.isnan(selected.mean(dim=0)).sum()==0:
+                initial_state[index] = selected.mean(dim=0)
 
         center_shift = torch.sum(
             torch.sqrt(


### PR DESCRIPTION
Dear,

When running the code, I also encountered the "center_shift=nan" bug (which was also reported in issue [#3](https://github.com/subhadarship/kmeans_pytorch/issues/3)). I would like to thank [@GenjiB](https://github.com/GenjiB) for identifying the issue: "If a cluster_center is an outlier, there are no neighbor points to calculate the mean point. To calculate the mean of none points results in Nan."

@GenjiB also proposed a solution that worked for me. To facilitate the use of this solution by others, we have modified the source code accordingly. Additionally, we found that numbda needs to be installed before running the code from source, and we have added a corresponding prompt in the ReadMe file.

Best regards,
Nianzu Yang